### PR TITLE
🚑 修复父类中的只读属性无法填充DataTable的Bug

### DIFF
--- a/Zack.EFCore.Batch/Internal/BulkInsertUtils.cs
+++ b/Zack.EFCore.Batch/Internal/BulkInsertUtils.cs
@@ -21,7 +21,7 @@ namespace Zack.EFCore.Batch.Internal
         public static DbProp[] ParseDbProps<TEntity>(IEntityType entityType) where TEntity : class
         {
             //skip navigationProperties
-            var props = typeof(TEntity).GetProperties().Where(p => !IsNavigationProp(entityType, p)&&p.CanWrite&&p.CanRead);
+            var props = typeof(TEntity).GetProperties().Where(p => !IsNavigationProp(entityType, p)&&p.CanRead);
             List<DbProp> propFields = new List<DbProp>();
 
             foreach (var prop in props)


### PR DESCRIPTION
如下代码可复现

```csharp
public class Blog : ModelBase
{
    public int BlogId { get; set; }

    public string Url { get; private set; }

    public Blog(Guid parentId, string url) : base(parentId)
    {
        Url = url;
    }

}

public abstract class ModelBase
{
    public virtual Guid ParentId { get; private set; }

    protected ModelBase(Guid parentId)
    {
        ParentId = parentId;
    }
}

var blogs = new List<Blog>();
blogs.Add(new Blog(Guid.NewGuid(), Guid.NewGuid().ToString()));

using (var db = new BloggingContext())
{
    db.BulkInsert(blogs);
}
```