### PR TITLE
fix: The given key '__ef_filter__p_0' was not present in the dictionary

### DIFF
--- a/Zack.EFCore.Batch/BatchEFExtensions.cs
+++ b/Zack.EFCore.Batch/BatchEFExtensions.cs
@@ -178,10 +178,6 @@ namespace System.Linq
         /// <returns></returns>
         public static SelectParsingResult Parse<TEntity>(this IQueryable<TEntity> queryable, DbContext ctx,bool ignoreQueryFilters) where TEntity:class
         {
-            if(ignoreQueryFilters)
-            {
-                queryable = queryable.IgnoreQueryFilters();
-            }            
             SelectParsingResult parsingResult = new SelectParsingResult();
             Expression query = queryable.Expression;
             var databaseDependencies = ctx.GetService<DatabaseDependencies>();

--- a/Zack.EFCore.Batch/Internal/BatchUpdateBuilder.cs
+++ b/Zack.EFCore.Batch/Internal/BatchUpdateBuilder.cs
@@ -120,6 +120,10 @@ namespace Zack.EFCore.Batch.Internal
             var selectExpression = Expression.Lambda<Func<TEntity, object>>(newArrayExp, parameter);
 
             IQueryable<TEntity> queryable = this.dbSet;
+            if (ignoreQueryFilters)
+            {
+                queryable = queryable.IgnoreQueryFilters();
+            }
             if (predicate!=null)
             {
                 queryable = queryable.Where(predicate);


### PR DESCRIPTION
The given key '__ef_filter__p_0' was not present in the dictionary #17 #50.

`IgnoreQueryFilters`  method needs to be before  `IQueryable<object> selectQueryable = queryable.Select(selectExpression)`.

**Detailed location:**
nullable = ParameterValues[sqlParameterExpression.Name] == null;
```
        protected virtual SqlExpression VisitSqlParameter(
            SqlParameterExpression sqlParameterExpression,
            bool allowOptimizedExpansion,
            out bool nullable)
        {
            Check.NotNull(sqlParameterExpression, nameof(sqlParameterExpression));

            nullable = ParameterValues[sqlParameterExpression.Name] == null;

            return nullable
                ? _sqlExpressionFactory.Constant(null, sqlParameterExpression.TypeMapping)
                : sqlParameterExpression;
        }
```

