### PR TITLE
修复Dic参数对象无法被 FromSqlRaw识别的问题

### DIFF
--- a/Zack.EFCore.Batch.MSSQL/Internal/ZackQuerySqlGenerator_MSSQL.cs
+++ b/Zack.EFCore.Batch.MSSQL/Internal/ZackQuerySqlGenerator_MSSQL.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Linq.Expressions;
 using Zack.EFCore.Batch.Internal;
 
@@ -111,6 +112,11 @@ namespace Zack.EFCore.Batch.MSSQL.Internal
         public void P_GenerateLimitOffset(SelectExpression selectExpression)
         {
             this.GenerateLimitOffset(selectExpression);
+        }
+
+        public DbParameter CreateParameter(string parameterName, object? parameterValue = null)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/Zack.EFCore.Batch.MSSQL/Internal/ZackQuerySqlGenerator_MSSQL.cs
+++ b/Zack.EFCore.Batch.MSSQL/Internal/ZackQuerySqlGenerator_MSSQL.cs
@@ -1,4 +1,5 @@
 ﻿#if (!NET7_0_OR_GREATER)
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.SqlServer.Query.Internal;
@@ -116,7 +117,7 @@ namespace Zack.EFCore.Batch.MSSQL.Internal
 
         public DbParameter CreateParameter(string parameterName, object? parameterValue = null)
         {
-            throw new NotImplementedException();
+            return new SqlParameter(parameterName, parameterValue);
         }
     }
 }

--- a/Zack.EFCore.Batch.MySQL.Pomelo/Internal/ZackQuerySqlGenerator_MySQLPomelo.cs
+++ b/Zack.EFCore.Batch.MySQL.Pomelo/Internal/ZackQuerySqlGenerator_MySQLPomelo.cs
@@ -1,11 +1,14 @@
 ﻿#if (!NET7_0_OR_GREATER)
 using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Storage;
+using MySqlConnector;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal;
 using Pomelo.EntityFrameworkCore.MySql.Query.Internal;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Linq.Expressions;
 using Zack.EFCore.Batch.Internal;
 
@@ -126,6 +129,11 @@ namespace Zack.EFCore.Batch.MySQL.Pomelo.Internal
 		{
 			this.GenerateLimitOffset(selectExpression);
 		}
-	}
+
+        public DbParameter CreateParameter(string parameterName, object? parameterValue = null)
+        {
+            return new MySqlParameter(parameterName, parameterValue);
+        }
+    }
 }
 #endif

--- a/Zack.EFCore.Batch.Npgsql/Internal/ZackQuerySqlGenerator_Npgsql.cs
+++ b/Zack.EFCore.Batch.Npgsql/Internal/ZackQuerySqlGenerator_Npgsql.cs
@@ -2,9 +2,11 @@
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Storage;
+using Npgsql;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Query.Internal;
 using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Linq.Expressions;
 using Zack.EFCore.Batch.Internal;
 
@@ -114,6 +116,11 @@ namespace Zack.EFCore.Batch.Npgsql.Internal
 		{
 			this.GenerateLimitOffset(selectExpression);
 		}
-	}
+
+        public DbParameter CreateParameter(string parameterName, object? parameterValue = null)
+        {
+            return new NpgsqlParameter(parameterName, parameterValue);
+        }
+    }
 }
 #endif

--- a/Zack.EFCore.Batch.Oracle/Internal/ZackQuerySqlGenerator_Oracle.cs
+++ b/Zack.EFCore.Batch.Oracle/Internal/ZackQuerySqlGenerator_Oracle.cs
@@ -7,6 +7,8 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using Zack.EFCore.Batch.Internal;
 using Oracle.EntityFrameworkCore.Infrastructure.Internal;
+using System.Data.Common;
+using Oracle.ManagedDataAccess.Client;
 
 namespace Zack.EFCore.Batch.Oracle.Internal
 {
@@ -114,6 +116,11 @@ namespace Zack.EFCore.Batch.Oracle.Internal
 		{
 			this.GenerateLimitOffset(selectExpression);
 		}
-	}
+
+        public DbParameter CreateParameter(string parameterName, object? parameterValue = null)
+        {
+            return new OracleParameter(parameterName, parameterValue);
+        }
+    }
 }
 #endif

--- a/Zack.EFCore.Batch.Sqlite/Internal/ZackQuerySqlGenerator_Sqlite.cs
+++ b/Zack.EFCore.Batch.Sqlite/Internal/ZackQuerySqlGenerator_Sqlite.cs
@@ -1,10 +1,12 @@
 ﻿#if (!NET7_0_OR_GREATER)
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Sqlite.Query.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Linq.Expressions;
 using Zack.EFCore.Batch.Internal;
 
@@ -114,6 +116,11 @@ namespace Zack.EFCore.Batch.Sqlite.Internal
 		{
 			this.GenerateLimitOffset(selectExpression);
 		}
-	}
+
+        public DbParameter CreateParameter(string parameterName, object? parameterValue = null)
+        {
+            return new SqliteParameter(parameterName, parameterValue);
+        }
+    }
 }
 #endif

--- a/Zack.EFCore.Batch/BatchEFExtensions.cs
+++ b/Zack.EFCore.Batch/BatchEFExtensions.cs
@@ -59,15 +59,7 @@ namespace System.Linq
 
         private static async Task<int> ExecuteSQLAsync(DbContext ctx, string sql, IDictionary<string, object> parameters, CancellationToken cancellationToken)
         {
-            var conn = ctx.Database.GetDbConnection();
-            await conn.OpenIfNeededAsync(cancellationToken);
-            using (var cmd = conn.CreateCommand())
-            {
-                cmd.ApplyCurrentTransaction(ctx);
-                cmd.CommandText = sql;
-                cmd.AddParameters(ctx, parameters);
-                return await cmd.ExecuteNonQueryAsync(cancellationToken);
-            }
+           return await ctx.Database.ExecuteSqlRawAsync(sql, parameters, cancellationToken);
         }
 
         public static async Task<int> DeleteRangeAsync<TEntity>(this IQueryable<TEntity> queryable, DbContext ctx,
@@ -98,15 +90,7 @@ namespace System.Linq
 
         private static int ExecuteSQL(DbContext ctx, string sql, IDictionary<string, object> parameters)
         {
-            var conn = ctx.Database.GetDbConnection();
-            conn.OpenIfNeeded();
-            using (var cmd = conn.CreateCommand())
-            {
-                cmd.ApplyCurrentTransaction(ctx);
-                cmd.CommandText = sql;
-                cmd.AddParameters(ctx, parameters);
-                return cmd.ExecuteNonQuery();
-            }
+            return ctx.Database.ExecuteSqlRawAsync(sql, parameters).Result;
         }
 
         internal static void ApplyCurrentTransaction(this IDbCommand cmd,DbContext dbContext)

--- a/Zack.EFCore.Batch/Internal/BatchUpdateBuilder.cs
+++ b/Zack.EFCore.Batch/Internal/BatchUpdateBuilder.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 using System.Data;
+using System.Data.Common;
 using System.Linq.Expressions;
 using System.Text;
 using System.Threading;
@@ -103,7 +104,7 @@ namespace Zack.EFCore.Batch.Internal
             return Set(nameExpr, valueLambdaExpr, propType);
         }
 
-        private string GenerateSQL(Expression<Func<TEntity, bool>> predicate, bool ignoreQueryFilters, out IDictionary<string, object> parameters)
+        private string GenerateSQL(Expression<Func<TEntity, bool>> predicate, bool ignoreQueryFilters, out List<DbParameter> parameters)
         {
             if (setters.Count <= 0)
             {
@@ -238,14 +239,14 @@ namespace Zack.EFCore.Batch.Internal
 
         public async Task<int> ExecuteAsync(bool ignoreQueryFilters = false, CancellationToken cancellationToken = default)
         {
-            string sql = GenerateSQL(this.predicate, ignoreQueryFilters,out IDictionary<string, object> parameters);
+            string sql = GenerateSQL(this.predicate, ignoreQueryFilters,out List<DbParameter> parameters);
             this.dbContext.Log($"Zack.EFCore.Batch: Sql={sql}");
             return await dbContext.Database.ExecuteSqlRawAsync(sql, parameters, cancellationToken);
         }
 
         public int Execute(bool ignoreQueryFilters=false)
         {
-            string sql = GenerateSQL(this.predicate, ignoreQueryFilters, out IDictionary<string, object> parameters);
+            string sql = GenerateSQL(this.predicate, ignoreQueryFilters, out List<DbParameter> parameters);
             this.dbContext.Log($"Zack.EFCore.Batch: Sql={sql}");
             return dbContext.Database.ExecuteSqlRawAsync(sql, parameters).Result;
         }

--- a/Zack.EFCore.Batch/Internal/IZackQuerySqlGenerator.cs
+++ b/Zack.EFCore.Batch/Internal/IZackQuerySqlGenerator.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Storage;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Linq.Expressions;
 
 namespace Zack.EFCore.Batch.Internal
@@ -38,7 +39,8 @@ namespace Zack.EFCore.Batch.Internal
 		public void P_GenerateOrderings(SelectExpression selectExpression);
 
 		public void P_GenerateLimitOffset(SelectExpression selectExpression);
+		public DbParameter CreateParameter(string parameterName, object? parameterValue = null);
 
-		public string P_AliasSeparator { get; }
+        public string P_AliasSeparator { get; }
 	}
 }

--- a/Zack.EFCore.Batch/Internal/SelectParsingResult.cs
+++ b/Zack.EFCore.Batch/Internal/SelectParsingResult.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Data.Common;
 
 namespace Zack.EFCore.Batch.Internal
 {
@@ -7,7 +8,7 @@ namespace Zack.EFCore.Batch.Internal
         /// <summary>
         /// parameters of query
         /// </summary>
-        public IDictionary<string, object> Parameters { get; internal set; }
+        public List<DbParameter> Parameters { get; internal set; }
        
 
         public string Schema

--- a/ZackEFCore.Batch.Dm/Internal/ZackQuerySqlGenerator_DM.cs
+++ b/ZackEFCore.Batch.Dm/Internal/ZackQuerySqlGenerator_DM.cs
@@ -1,8 +1,10 @@
-﻿using Microsoft.EntityFrameworkCore.Dm.Query.Internal;
+﻿using Dm;
+using Microsoft.EntityFrameworkCore.Dm.Query.Internal;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Storage;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Linq.Expressions;
 using Zack.EFCore.Batch.Internal;
 
@@ -108,6 +110,11 @@ namespace Zack.EFCore.Batch.DM.Internal
         public void P_GenerateLimitOffset(SelectExpression selectExpression)
         {
             this.GenerateLimitOffset(selectExpression);
+        }
+
+        public DbParameter CreateParameter(string parameterName, object parameterValue = null)
+        {
+            return new DmParameter(parameterName, parameterValue);
         }
     }
 }


### PR DESCRIPTION
修复Dic参数对象无法被 FromSqlRaw识别的问题
主要将参数的传递方式由Dic<string,object>改为DBParameter形式
在IZackQuerySqlGenerator中添加CreateParameter方法 并在各个不同的库中进行了实现